### PR TITLE
Remove exception support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ all:
 	cd llvm-project && \
 	mkdir build || true && \
 	cmake -G Ninja -S llvm -B build \
+	-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF \
+	-DLIBCXX_ENABLE_EXCEPTIONS=OFF \
 	-DLIBCXX_ENABLE_THREADS=OFF \
 	-DLIBCXX_HAS_PTHREAD_API=OFF \
 	-DLLVM_ENABLE_THREADS=OFF \


### PR DESCRIPTION
I'm removing exception support at the moment because caffeine does not
implement the required libunwind interface. When we implement that, this
commit can be reverted.