### PR TITLE
Compile libcxx and libcxxabi on Alpine

### DIFF
--- a/.github/workflows/build-libcxx.yml
+++ b/.github/workflows/build-libcxx.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   build:
-    runs-on: insufficientlycaffeinated/alpine-bob:latest
+    runs-on: ubuntu-latest
+    container:
+      image: insufficientlycaffeinated/alpine-bob:latest
     steps:
       - uses: actions/checkout@v2
       - name: Build

--- a/.github/workflows/build-libcxx.yml
+++ b/.github/workflows/build-libcxx.yml
@@ -5,25 +5,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: insufficientlycaffeinated/alpine-bob:latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '^1.16.6'
-      - name: Install required dependencies
-        # ubuntu-latest already has many of the packages we want installed. See
-        # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
-        run: |
-          sudo apt update
-          sudo apt-get install -y \
-            ninja-build \
-            libgtest-dev \
-            libfmt-dev \
-            libboost-all-dev
-          sudo ./.github/scripts/update-alternatives-llvm.sh 11 20
-          go get github.com/SRI-CSL/gllvm/cmd/...
-
       - name: Build
         run: make
       - uses: ncipollo/release-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.15
+
+COPY --from=golang:1.17-alpine /usr/local/go/ /usr/local/go/
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache git make cmake ninja llvm12-dev clang binutils musl-dev gcc clang-dev build-base python3
+RUN go install github.com/SRI-CSL/gllvm/...@v1.3.0
+ENV PATH="/root/go/bin:/usr/local/go/bin/:${PATH}"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 # This could just be a shell or bash script but I'm fine with this
 .PHONY: all
 all:
-	git submodule init
-	git submodule update
+	git submodule update --init --depth 1
 	cd llvm-project && \
 	mkdir build || true && \
 	cmake -G Ninja -S llvm -B build \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ all:
 	-DLIBCXXABI_HAS_WIN32_THREAD_API=OFF \
 	-DLIBCXXABI_HAS_EXTERNAL_THREAD_API=OFF \
 	-DLIBCXXABI_BUILD_EXTERNAL_THREAD_LIBRARY=OFF \
+	-DLIBCXX_HAS_MUSL_LIBC=ON \
+	-DLIBCXX_ENABLE_SHARED=OFF \
+	-DLIBCXXABI_ENABLE_SHARED=OFF \
+	-DLIBCXXABI_LINK_TESTS_WITH_SHARED_LIBCXXABI=OFF \
 	-DLLVM_ENABLE_PROJECTS="libcxx;libcxxabi" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gclang -DCMAKE_CXX_COMPILER=gclang++ && \
 	ninja -C build cxx cxxabi && \
 	ninja -C build install-cxx install-cxxabi
@@ -33,3 +37,7 @@ all:
 	cp ll/libcxx.bc build/libcxx/lib/
 	tar -czvf libcxx.tar.gz build/libcxx/
 	mv libcxx.tar.gz ll/
+
+.PHONY: clean
+clean:
+	rm -rf build llvm-project/build ll

--- a/README.md
+++ b/README.md
@@ -11,3 +11,21 @@ Depends on:
 
 To get the LLVM IR just run `make` in the root directory
 and find all the files in `ll/`
+
+## Alpine Docker build
+
+Currently, the build is set up to work on an Alpine Docker container.
+To make the Docker image:
+```bash
+docker build - < Dockerfile
+sudo docker tag "<tag from prev cmd>" insufficientlycaffeinated/alpine-bob:latest
+docker run -v "<path to repo>":/build -it insufficientlycaffeinated/alpine-bob:latest /bin/sh
+(docker shell) cd build
+(docker shell) make clean
+(docker shell) make
+```
+
+To deploy the Docker container to the Docker registry:
+```bash
+docker push insufficientlycaffeinated/alpine-bob:latest
+```


### PR DESCRIPTION
We're compiling on Alpine because Alpine uses musl libc by default. We
want this because caffeine uses musl libc as our stdlib